### PR TITLE
Fix/no searchbar and title margin for mobile

### DIFF
--- a/config.js
+++ b/config.js
@@ -14,7 +14,7 @@ const config = {
     tweetText: '',
     links: [{ text: '', link: '' }],
     search: {
-      enabled: true,
+      enabled: false,
       indexName: 'relay-kr',
       // algoliaAppId: process.env.GATSBY_ALGOLIA_APP_ID,
       // algoliaSearchKey: process.env.GATSBY_ALGOLIA_SEARCH_KEY,

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -15,7 +15,7 @@ const isSearchEnabled = config.header.search && config.header.search.enabled ? t
 
 let searchIndices = [];
 
-if (isSearchEnabled && config.header.search.indexName) {
+if (config.header.search.indexName) {
   searchIndices.push({
     name: `${config.header.search.indexName}`,
     title: `Results`,
@@ -103,7 +103,9 @@ const Header = ({ location, isDarkThemeActive, toggleActiveTheme }) => (
               <div className={'searchWrapper hiddenMobile navBarUL'}>
                 <LoadableComponent collapse={true} indices={searchIndices} />
               </div>
-            ) : null}
+            ) : <div className={'searchWrapper hiddenMobile navBarUL hiddenSearchBar'}>
+              <LoadableComponent collapse={true} indices={searchIndices} />
+            </div>}
             <div id="navbar" className={'topnav'}>
               <div className={'visibleMobile'}>
                 <Sidebar location={location} />

--- a/src/components/styles/GlobalStyles.js
+++ b/src/components/styles/GlobalStyles.js
@@ -559,6 +559,10 @@ export const baseStyles = css`
     font-weight: 400;
   }
 
+  .hiddenSearchBar {
+    visibility: hidden !important;
+  }
+
   /* **************************** */
 
   .nextRightWrapper {

--- a/src/components/styles/GlobalStyles.js
+++ b/src/components/styles/GlobalStyles.js
@@ -271,6 +271,7 @@ export const baseStyles = css`
     position: fixed;
     height: 80px;
     width: 100%;
+margin-right: 15px;
   }
   .navBarHeader {
     min-width: 335px;
@@ -761,6 +762,7 @@ export const baseStyles = css`
     .headerTitle {
       padding-right: 50px;
       font-size: 16px;
+      margin-left: 45px;
     }
     .navBarBrand {
       min-height: 40px;

--- a/src/components/styles/GlobalStyles.js
+++ b/src/components/styles/GlobalStyles.js
@@ -762,7 +762,6 @@ margin-right: 15px;
     .headerTitle {
       padding-right: 50px;
       font-size: 16px;
-      margin-left: 45px;
     }
     .navBarBrand {
       min-height: 40px;
@@ -813,13 +812,14 @@ margin-right: 15px;
     .navBarDefault {
       display: block;
       height: auto;
+      width: 100vw;
     }
 
     .navBarToggle {
       margin-right: 0;
       display: block;
       position: absolute;
-      left: 11px;
+      right: 11px;
       top: 15px;
       background: #fff;
     }


### PR DESCRIPTION
# 모바일 환경에서 title 이 햄버거 메뉴를 가리지 않도록 변경

## Before Fix
<img width="372" alt="스크린샷 2022-03-14 오후 6 04 30" src="https://user-images.githubusercontent.com/10165823/158139750-19722333-7698-4af4-a5dd-71179914f8bb.png">

## After Fix
<img width="370" alt="스크린샷 2022-03-14 오후 6 04 41" src="https://user-images.githubusercontent.com/10165823/158139813-5513a1aa-4b97-455a-9e2b-180936d2ddd0.png">

# 검색창 안 나타나도록 변경

- algolia 설정을 하지 않아 인덱싱한 값들이 없어 검색을 지원하지 않는 것으로 보여 config.js 에서 옵션을 false 로 두어 검색창을 가렸어요

- 검색창을 가리면 레이아웃이 부자연스러운 모습을 보여서 rendering 은 하되, visibility 에 hidden 옵션을 주는 방식으로 가렸어요. 
    - *임시방편!*
