### PR TITLE
ci: gatsby build && gh-pages deploy

### DIFF
--- a/.github/workflow/deploy.yml
+++ b/.github/workflow/deploy.yml
@@ -1,0 +1,19 @@
+on:
+  push:
+    branches:
+      - main
+
+name: 배포
+
+jobs:
+  build-n-deploy:
+    name: gatsby를 빌드하고 gh-pages로 배포해요.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: yarn install
+        run: yarn install
+
+      - name: yarn build && yarn gh-pages
+        run: yarn deploy

--- a/.github/workflow/deploy.yml
+++ b/.github/workflow/deploy.yml
@@ -1,9 +1,9 @@
+name: 배포
+
 on:
   push:
     branches:
       - main
-
-name: 배포
 
 jobs:
   build-n-deploy:

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "description": "relay docs in korean",
   "author": "daangn Inc. <study-relay@daangn.com>",
+  "homepage": "https://daangn.github.io/relay-kr",
   "version": "0.0.1",
   "dependencies": {
     "@babel/plugin-proposal-export-default-from": "^7.12.13",

--- a/src/templates/docs.js
+++ b/src/templates/docs.js
@@ -28,11 +28,11 @@ export default class MDXRuntimeTest extends Component {
     const githubIcon = require('../components/images/github.svg').default;
     const navItems = allMdx.edges
       .map(({ node }) => node.fields.slug)
-      .filter(slug => slug !== '/')
+      .filter((slug) => slug !== '/')
       .sort()
       .reduce(
         (acc, cur) => {
-          if (forcedNavOrder.find(url => url === cur)) {
+          if (forcedNavOrder.find((url) => url === cur)) {
             return { ...acc, [cur]: [cur] };
           }
 
@@ -42,7 +42,7 @@ export default class MDXRuntimeTest extends Component {
             prefix = prefix + '/';
           }
 
-          if (prefix && forcedNavOrder.find(url => url === `/${prefix}`)) {
+          if (prefix && forcedNavOrder.find((url) => url === `/${prefix}`)) {
             return { ...acc, [`/${prefix}`]: [...acc[`/${prefix}`], cur] };
           } else {
             return { ...acc, items: [...acc.items, cur] };
@@ -56,7 +56,7 @@ export default class MDXRuntimeTest extends Component {
         return acc.concat(navItems[cur]);
       }, [])
       .concat(navItems.items)
-      .map(slug => {
+      .map((slug) => {
         if (slug) {
           const { node } = allMdx.edges.find(({ node }) => node.fields.slug === slug);
 
@@ -65,7 +65,7 @@ export default class MDXRuntimeTest extends Component {
       });
 
     // meta tags
-    const metaTitle = mdx.frontmatter.metaTitle;
+    const metaTitle = title;
 
     const metaDescription = mdx.frontmatter.metaDescription;
 
@@ -111,7 +111,7 @@ export default class MDXRuntimeTest extends Component {
 }
 
 export const pageQuery = graphql`
-  query($id: String!) {
+  query ($id: String!) {
     site {
       siteMetadata {
         title


### PR DESCRIPTION
- main 브랜치로 푸시할 시 빌드 및 배포 ci를 세팅했어요.
- yarn deploy가 실행되면 `gh-pages` 브랜치에 빌드 artifacts가 저장되고, github pages가 해당 브랜치로부터 배포를 진행해요.